### PR TITLE
Allow select source model to be instantiated elsewhere

### DIFF
--- a/app/code/community/Aligent/CustomFormElements/Block/Adminhtml/Element/Select.php
+++ b/app/code/community/Aligent/CustomFormElements/Block/Adminhtml/Element/Select.php
@@ -6,6 +6,12 @@ class Aligent_CustomFormElements_Block_Adminhtml_Element_Select extends Mage_Cor
     protected $_bRequired = false;
 
     public function setOptionSource($vSourceClassName) {
+        if (is_object($vSourceClassName)) {
+            $oSource = $vSourceClassName;
+        } else {
+            $oSource = Mage::getSingleton($vSourceClassName);
+        }
+
         $oSource = Mage::getSingleton($vSourceClassName);
         if (method_exists($oSource, 'toOptionArray')) {
             $this->_oOptions = $oSource->toOptionArray();


### PR DESCRIPTION
Allows the source model to be instantiated by the block which is
setting up the table field.  This allows the use of standard EAV
table source models which need to be initialised with an attribute
before getAllOptions can be called.